### PR TITLE
Add option for proportional string spacing

### DIFF
--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -558,18 +558,17 @@ Fret  P.D.    Fret  P.D.
                 </dd>
             </dl>
         </dd>
-
         <dt>string width at the bridge</dt>
         <dd><input type="text" id="bridgeWidth" value="2.125" /></dd>
         <dd class="help">
-            The string width at the bridge is the distance along the bridge from the center 
-            of the first string to the center of the last string.            
-            I'm using delta x distance 
+            The string width at the bridge is the distance along the bridge from the center
+            of the first string to the center of the last string.
+            I'm using delta x distance
             (distance measured along a line drawn perpendicular to the neck's midline)
-            because I think that is what 
-            you would feel as the width if you were playing an instrument with multiple scale lengths. 
+            because I think that is what
+            you would feel as the width if you were playing an instrument with multiple scale lengths.
             It also makes the calculation easier.
-            (Please note, FretFind will space 
+            (Please note, FretFind will space
             the remaining strings equally between these two points.)
         </dd>
         <dt>fretboard overhang</dt>

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -71,8 +71,6 @@ var setGauges = function(gauge_id, string_count_id, change_callback, gauges) {
 
 // computes string offsets along the nut itself, assuming that width does not include the overhang (it's already accounted for)
 var computeProportionalOffsets = function(strings, gauges, actual_length, perp_width) {
-    // the first and last strings have been shifted to the left/right of the overhang-defined lines by half of their gauges,
-    // so we start with an effective offset of 0.
     var offsets = [0];
     const working_area = perp_width - gauges.reduce((tot, cur) => tot + cur); 
     const perp_gap = working_area / (strings - 1);
@@ -159,13 +157,6 @@ var getGuitar = function() {
     var sbxf = xcenter + bridgeHalf;
     var snxl = xcenter - nutHalf;
     var sbxl = xcenter - bridgeHalf;
-
-    if (spacing === 'proportional') {
-        snxf -= gauges[strings-1]/2.0;
-        snxl += gauges[0]/2.0;
-        sbxf -= gauges[strings-1]/2.0;
-        sbxl += gauges[0]/2.0;
-    }
 
     //find the slope of the strings
     var fdeltax = sbxf - snxf;

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -606,7 +606,7 @@ Fret  P.D.    Fret  P.D.
                         </dd>
                     </dl>
                 </dd>
-                <dd class="help">Proportional nut spacing accounts for the diameter of the strings so that the empty space between each string is the same, rather than simply spacing out the strings evenly from center to center.</dd>
+                <dd class="help">Proportional nut spacing accounts for the diameter of the strings so that the empty space between each string is the same, rather than simply spacing out the strings evenly from center to center. Note that the outer two strings are still assumed to be centered on their coordinates, i.e. if you enter a nut width of 2" then the outer edges of your outer two strings will be wider than that by half of the sum of their gauges.</dd>
             </dl>
         </dd>
 

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -70,12 +70,15 @@ var setGauges = function(gauge_id, string_count_id, change_callback, gauges) {
 };
 
 // computes string offsets along the nut itself, assuming that width does not include the overhang (it's already accounted for)
-var computeProportionalOffsets = function(strings, gauges, actual_length, perp_width) {
+// if "proportional" is not selected, gauges will all b 0 and this will simply return
+// the offsets along the nut. 
+var computeOffsets = function(strings, gauges, actual_length, perp_width, spacingMode) {
     var offsets = [0];
-    const working_area = perp_width - gauges.reduce((tot, cur) => tot + cur); 
+    const corrected_gauges = spacingMode === 'proportional' ? gauges : new Array(strings).fill(0);
+    const working_area = perp_width - corrected_gauges.reduce((tot, cur) => tot + cur); 
     const perp_gap = working_area / (strings - 1);
     for (var i=1; i<strings-1; i++) {
-        half_adjacent_strings = (gauges[i-1] + gauges[i]) / 2.0;
+        half_adjacent_strings = (corrected_gauges[i-1] + corrected_gauges[i]) / 2.0;
         next_space = perp_gap + half_adjacent_strings; 
         offsets.push(offsets[i-1] + next_space * actual_length / perp_width);
     }
@@ -217,24 +220,14 @@ var getGuitar = function() {
       perp_y += move;
     }
 
-    var nutStringSpacing = nut.length() / (strings - 1);
-    var bridgeStringSpacing = bridge.length() / (strings - 1);
-
+    var nutOffsets = computeOffsets(strings, gauges, nut.length(), nutWidth, spacingMode);
+    var bridgeOffsets = computeOffsets(strings, gauges, bridge.length(), bridgeWidth, spacingMode); 
     
-    if (spacingMode === 'proportional') {
-        var nutOffsets = computeProportionalOffsets(strings, gauges, nut.length(), nutWidth);
-        var bridgeOffsets = computeProportionalOffsets(strings, gauges, bridge.length(), bridgeWidth); 
-    }
     var lines = [first];
     for (var i=1; i<=(strings-2); i++)
     {
-      if (spacingMode === 'proportional') {
-        var n = nut.pointAt(nutOffsets[i]);
-        var b = bridge.pointAt(bridgeOffsets[i]);
-      } else {
-       var n = nut.pointAt(i * nutStringSpacing);
-       var b = bridge.pointAt(i * bridgeStringSpacing);
-      } 
+      var n = nut.pointAt(nutOffsets[i]);
+      var b = bridge.pointAt(bridgeOffsets[i]);
       
       if (lengthMode === 'individual') {
         var l = lengths[i];

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -72,7 +72,7 @@ var setGauges = function(gauge_id, string_count_id, change_callback, gauges) {
 // computes spacing, assuming that width does not include the overhang (it's already accounted for)
 var computeProportionalOffsets = function(strings, gauges, width) {
     var offsets = [0];
-    const working_area = width - gauges.reduce((tot, cor) => tot + cur);
+    const working_area = width - gauges.reduce((tot, cur) => tot + cur);
     const distance = working_area / (strings - 1);
     for (var i=1; i<strings; i++) {
         offsets.push(offsets[i-1] + gauges[i-1]/2 + distance + gauges[i]/2);
@@ -96,11 +96,8 @@ var getGuitar = function() {
     var strings = ff.getInt('numStrings');
     var units = $("input:checked[name='units']").val();
 
-    if (spacingMode === 'proportional') {
-        var gauges = getGauges('igauges');
-    }
-    var lengths = getLengths('ilengths');
     var gauges = getGauges('igauges');
+    var lengths = getLengths('ilengths');
     if (lengthMode === 'individual') {
       scaleLengthF = lengths[0];
       scaleLengthL = lengths[lengths.length-1];
@@ -221,16 +218,23 @@ var getGuitar = function() {
     var nutStringSpacing = nut.length() / (strings - 1);
     var bridgeStringSpacing = bridge.length() / (strings - 1);
 
+    console.log(spacingMode);
+    console.log(lengthMode);
     if (spacingMode === 'proportional') {
         var nutOffsets = computeProportionalOffsets(strings, gauges, nutWidth);
         var bridgeOffsets = computeProportionalOffsets(strings, gauges, bridgeWidth);  
     }
-
     var lines = [first];
     for (var i=1; i<=(strings-2); i++)
     {
-      var n=nut.pointAt(i * nutStringSpacing);
-      var b=bridge.pointAt(i * bridgeStringSpacing);
+      if (spacingMode === 'proportional') {
+        var n = nut.pointAt(nutOffsets[i]);
+        var b = bridge.pointAt(bridgeOffsets[i]);
+      } else {
+       var n = nut.pointAt(i * nutStringSpacing / 2);
+       var b = bridge.pointAt(i * bridgeStringSpacing / 2);
+      } 
+      
       if (lengthMode === 'individual') {
         var l = lengths[i];
         var nx = n.x;
@@ -271,6 +275,7 @@ var getLink = function() {
     params.ig = getGauges('igauges');
     params.u = $("input:checked[name='units']").val();
     params.sl = ff.getAlt('length');
+    params.ns = ff.getAlt('spacing');
     params.scale = ff.getAlt('scale');
     params.o = ff.getAlt('overhang');
     var location = window.location.toString().replace(/#.*/,'');
@@ -304,6 +309,7 @@ var updateFormFromHash = function() {
     ff.setTuning('tuning','numStrings', onChange, (params['t'] || []));
     $("input[name='units']").filter("[value='"+(params['u']||'in')+"']").click();
     $('#'+params.sl).click();
+    $('#'+params.ns).click();
     $('#'+params.scale).click();
     $('#'+params.o).click();
 };
@@ -586,9 +592,9 @@ Fret  P.D.    Fret  P.D.
         </dd>
         <dt>nut spacing</dt>
         <dd>
-            <dl id=“spacing” class="alternative">
-                <dt id=“equal”>equal</dt>
-                <dt id=“proportional”>proportional</dt>
+            <dl id="spacing" class="alternative">
+                <dt id="equal">equal</dt>
+                <dt id="proportional">proportional</dt>
                 <dd>
                     <dl>
                         <dt>string gauges:</dt>

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -69,13 +69,17 @@ var setGauges = function(gauge_id, string_count_id, change_callback, gauges) {
     $('#'+gauge_id+' > input').change(change_callback);
 };
 
-// computes spacing, assuming that width does not include the overhang (it's already accounted for)
-var computeProportionalOffsets = function(strings, gauges, width) {
+// computes string offsets along the nut itself, assuming that width does not include the overhang (it's already accounted for)
+var computeProportionalOffsets = function(strings, gauges, actual_length, perp_width) {
+    // the first and last strings have been shifted to the left/right of the overhang-defined lines by half of their gauges,
+    // so we start with an effective offset of 0.
     var offsets = [0];
-    const working_area = width - gauges.reduce((tot, cur) => tot + cur);
-    const distance = working_area / (strings - 1);
-    for (var i=1; i<strings; i++) {
-        offsets.push(offsets[i-1] + gauges[i-1]/2 + distance + gauges[i]/2);
+    const working_area = perp_width - gauges.reduce((tot, cur) => tot + cur); 
+    const perp_gap = working_area / (strings - 1);
+    for (var i=1; i<strings-1; i++) {
+        half_adjacent_strings = (gauges[i-1] + gauges[i]) / 2.0;
+        next_space = perp_gap + half_adjacent_strings; 
+        offsets.push(offsets[i-1] + next_space * actual_length / perp_width);
     }
     return offsets;
 };
@@ -156,6 +160,13 @@ var getGuitar = function() {
     var snxl = xcenter - nutHalf;
     var sbxl = xcenter - bridgeHalf;
 
+    if (spacing === 'proportional') {
+        snxf -= gauges[strings-1]/2.0;
+        snxl += gauges[0]/2.0;
+        sbxf -= gauges[strings-1]/2.0;
+        sbxl += gauges[0]/2.0;
+    }
+
     //find the slope of the strings
     var fdeltax = sbxf - snxf;
     var ldeltax = sbxl - snxl;
@@ -218,11 +229,9 @@ var getGuitar = function() {
     var nutStringSpacing = nut.length() / (strings - 1);
     var bridgeStringSpacing = bridge.length() / (strings - 1);
 
-    console.log(spacingMode);
-    console.log(lengthMode);
     if (spacingMode === 'proportional') {
-        var nutOffsets = computeProportionalOffsets(strings, gauges, nutWidth);
-        var bridgeOffsets = computeProportionalOffsets(strings, gauges, bridgeWidth);  
+        var nutOffsets = computeProportionalOffsets(strings, gauges, nut.length(), nutWidth);
+        var bridgeOffsets = computeProportionalOffsets(strings, gauges, bridge.length(), bridgeWidth); 
     }
     var lines = [first];
     for (var i=1; i<=(strings-2); i++)
@@ -231,8 +240,8 @@ var getGuitar = function() {
         var n = nut.pointAt(nutOffsets[i]);
         var b = bridge.pointAt(bridgeOffsets[i]);
       } else {
-       var n = nut.pointAt(i * nutStringSpacing / 2);
-       var b = bridge.pointAt(i * bridgeStringSpacing / 2);
+       var n = nut.pointAt(i * nutStringSpacing);
+       var b = bridge.pointAt(i * bridgeStringSpacing);
       } 
       
       if (lengthMode === 'individual') {

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -541,6 +541,24 @@ Fret  P.D.    Fret  P.D.
             (Please note, FretFind will space 
             the remaining strings equally between these two points.)
         </dd>
+        <dt>nut spacing</dt>
+        <dd>
+            <dl id=“spacing” class="alternative">
+                <dt id=“equal”>equal</dt>
+                <dt id=“proportional”>proportional</dt>
+                <dd>
+                    <dl>
+                        <dt>string gauges:</dt>
+                        <dd id=“igauges”>
+                        </dd>
+                        <dd class="help">
+                            Enter the thickness of each string.
+                        </dd>
+                    </dl>
+                </dd>
+            </dl>
+        </dd>
+
         <dt>string width at the bridge</dt>
         <dd><input type="text" id="bridgeWidth" value="2.125" /></dd>
         <dd class="help">

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -113,7 +113,7 @@ var getGuitar = function() {
     var oNL;
     var oBF;
     var oBL;
-    switch (ff.getAlt('overhang')) { 
+    switch (ff.getAlt('overhang')) {
       case 'equal':
         oNF = oNL = oBF = oBL = ff.getFlt('oE');
         break;
@@ -229,6 +229,7 @@ var getGuitar = function() {
     var nutStringSpacing = nut.length() / (strings - 1);
     var bridgeStringSpacing = bridge.length() / (strings - 1);
 
+    
     if (spacingMode === 'proportional') {
         var nutOffsets = computeProportionalOffsets(strings, gauges, nut.length(), nutWidth);
         var bridgeOffsets = computeProportionalOffsets(strings, gauges, bridge.length(), bridgeWidth); 

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -611,10 +611,11 @@ Fret  P.D.    Fret  P.D.
                         <dd id="igauges">
                         </dd>
                         <dd class="help">
-                            Enter the thickness of each string.
+                            Enter the thickness of each string, with String 1 being the thinnest/highest. For example, a standard set of electric guitar strings, in inches, would be 0.010, 0.013, 0.017, 0.026, 0.036, 0.046. If you are using metric, please convert your string gauges to metric as well.
                         </dd>
                     </dl>
                 </dd>
+                <dd class="help">Proportional nut spacing accounts for the diameter of the strings so that the empty space between each string is the same, rather than simply spacing out the strings evenly from center to center.</dd>
             </dl>
         </dd>
 

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -51,11 +51,42 @@ var setLengths = function(length_id, string_count_id, change_callback, lengths) 
     $('#'+length_id+' > input').change(change_callback);
 };
 
+var getGauges = function(id) {
+    var gauges = [];
+    $('#'+id+' > input').each(function(_,item){gauges.push(parseFloat(item.value));});
+    return gauges;
+};
+var setGauges = function(gauge_id, string_count_id, change_callback, gauges) {
+    var strings = ff.getInt(string_count_id);
+    if (typeof gauges === 'undefined') {
+        gauges = getGauges(gauge_id);
+    }
+    var output = '';
+    for (var i=0; i<strings; i++) {
+        output += 'string '+(i+1)+': <input type="text" value="'+(gauges[i] || 0.0)+'" /><br />';
+    }
+    $('#'+gauge_id).html(output);
+    $('#'+gauge_id+' > input').change(change_callback);
+};
+
+// computes spacing, assuming that width does not include the overhang (it's already accounted for)
+var computeProportionalOffsets = function(strings, gauges, width) {
+    var offsets = [0];
+    const working_area = width - gauges.reduce((tot, cor) => tot + cur);
+    const distance = working_area / (strings - 1);
+    for (var i=1; i<strings; i++) {
+        offsets.push(offsets[i-1] + gauges[i-1]/2 + distance + gauges[i]/2);
+    }
+    return offsets;
+};
+
+
 // output a guitar (scale, tuning and strings (with fretboard edges))
 // based upon form values
 var getGuitar = function() {
     //get form values
     var lengthMode = ff.getAlt('length');
+    var spacingMode = ff.getAlt('spacing');
     var scaleLength = ff.getFlt('len');
     var scaleLengthF = ff.getFlt('lenF');
     var scaleLengthL = ff.getFlt('lenL');
@@ -65,7 +96,11 @@ var getGuitar = function() {
     var strings = ff.getInt('numStrings');
     var units = $("input:checked[name='units']").val();
 
+    if (spacingMode === 'proportional') {
+        var gauges = getGauges('igauges');
+    }
     var lengths = getLengths('ilengths');
+    var gauges = getGauges('igauges');
     if (lengthMode === 'individual') {
       scaleLengthF = lengths[0];
       scaleLengthL = lengths[lengths.length-1];
@@ -77,7 +112,7 @@ var getGuitar = function() {
     var oNL;
     var oBF;
     var oBL;
-    switch (ff.getAlt('overhang')) {
+    switch (ff.getAlt('overhang')) { 
       case 'equal':
         oNF = oNL = oBF = oBL = ff.getFlt('oE');
         break;
@@ -186,6 +221,10 @@ var getGuitar = function() {
     var nutStringSpacing = nut.length() / (strings - 1);
     var bridgeStringSpacing = bridge.length() / (strings - 1);
 
+    if (spacingMode === 'proportional') {
+        var nutOffsets = computeProportionalOffsets(strings, gauges, nutWidth);
+        var bridgeOffsets = computeProportionalOffsets(strings, gauges, bridgeWidth);  
+    }
 
     var lines = [first];
     for (var i=1; i<=(strings-2); i++)
@@ -229,6 +268,7 @@ var getLink = function() {
     });
     params.t = ff.getTuning('tuning');
     params.il = getLengths('ilengths');
+    params.ig = getGauges('igauges');
     params.u = $("input:checked[name='units']").val();
     params.sl = ff.getAlt('length');
     params.scale = ff.getAlt('scale');
@@ -260,6 +300,7 @@ var updateFormFromHash = function() {
         }
     });
     setLengths('ilengths','numStrings', onChange, (params['il'] || []));
+    setGauges('igauges', 'numStrings', onChange, (params['ig'] || []));
     ff.setTuning('tuning','numStrings', onChange, (params['t'] || []));
     $("input[name='units']").filter("[value='"+(params['u']||'in')+"']").click();
     $('#'+params.sl).click();
@@ -273,10 +314,12 @@ $(document).ready(function() {
     $('#numStrings').change(function(){
       ff.setTuning('tuning', 'numStrings', onChange);
       setLengths('ilengths','numStrings', onChange);
+      setGauges('igauges', 'numStrings', onChange);
     });
     $('#worksheet').find('input, textarea').change(onChange);
     ff.setTuning('tuning', 'numStrings', onChange);
     setLengths('ilengths','numStrings', onChange);
+    setGauges('igauges', 'numStrings', onChange);
     paper = Raphael('diagram',200,800);
     updateFormFromHash();
     processChanges = true;
@@ -549,7 +592,7 @@ Fret  P.D.    Fret  P.D.
                 <dd>
                     <dl>
                         <dt>string gauges:</dt>
-                        <dd id=“igauges”>
+                        <dd id="igauges">
                         </dd>
                         <dd class="help">
                             Enter the thickness of each string.

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -70,7 +70,7 @@ var setGauges = function(gauge_id, string_count_id, change_callback, gauges) {
 };
 
 // computes string offsets along the nut itself, assuming that width does not include the overhang (it's already accounted for)
-// if "proportional" is not selected, gauges will all b 0 and this will simply return
+// if "proportional" is not selected, gauges will all be 0 and this will simply return
 // the offsets along the nut. 
 var computeOffsets = function(strings, gauges, actual_length, perp_width, spacingMode) {
     var offsets = [0];

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -558,17 +558,18 @@ Fret  P.D.    Fret  P.D.
                 </dd>
             </dl>
         </dd>
+
         <dt>string width at the bridge</dt>
         <dd><input type="text" id="bridgeWidth" value="2.125" /></dd>
         <dd class="help">
-            The string width at the bridge is the distance along the bridge from the center
-            of the first string to the center of the last string.
-            I'm using delta x distance
+            The string width at the bridge is the distance along the bridge from the center 
+            of the first string to the center of the last string.            
+            I'm using delta x distance 
             (distance measured along a line drawn perpendicular to the neck's midline)
-            because I think that is what
-            you would feel as the width if you were playing an instrument with multiple scale lengths.
+            because I think that is what 
+            you would feel as the width if you were playing an instrument with multiple scale lengths. 
             It also makes the calculation easier.
-            (Please note, FretFind will space
+            (Please note, FretFind will space 
             the remaining strings equally between these two points.)
         </dd>
         <dt>fretboard overhang</dt>


### PR DESCRIPTION
Many high-end guitars, especially nylon-strings guitars and basses, use [proportional string spacing](https://www.projectguitar.com/tutorials/instrument-building/equal-vs-proportional-string-spacing-r15/) instead of equal spacing. 

This PR adds the option to enter string gauges and space the strings equally. 

~~EDIT: the gauges need to be converted to fractions of nut width before this can be merged. Converted to draft.~~ 