### PR TITLE
Extended fret ends and user-selectable display options

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  php-apache-environment:
+    container_name: FretFind2D-php-apache
+    image: php:8.0-apache
+    volumes:
+      - ../src:/var/www/html/
+    ports:
+      - 8000:80

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -436,8 +436,8 @@ as well as fretboards for instruments that play just or meantone scales.
     <dl id="worksheet">
         <dd>units</dd>
         <dd>
-            <label><input type="radio" name="units" value="in" checked="checked"/>inches</label>
-            <label><input type="radio" name="units" value="cm" />centimeters</label>
+            <label><input type="radio" name="units" value="in" checked="checked"/>inches</label><br />
+            <label><input type="radio" name="units" value="cm" />centimeters</label><br />
             <label><input type="radio" name="units" value="mm" />millimeters</label>
         </dd>
         <dd>display</dd>

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -359,8 +359,9 @@ $(document).ready(function() {
     
         dl.append('<dt>PDF (multi-page)</dt>' +
             '<dd>' +
-                '<label><input type="radio" name="pdfm_pagesize" value="letter" checked="checked"/>letter</label>' +
-                '<label><input type="radio" name="pdfm_pagesize" value="a4" />A4</label>' +
+                '<label><input type="radio" name="pdfm_pagesize" value="letter" checked="checked"/>letter</label><br />' +
+                '<label><input type="radio" name="pdfm_pagesize" value="a4" />A4</label><br />' +
+                '<label><input type="radio" name="pdfm_pagesize" value="legal" />legal</label>' +
             '</dd>' +
             '<dd><button id="download_pdfm">Download</button></dd>');
         $('#download_pdfm').click(function(){

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -89,14 +89,18 @@ var computeOffsets = function(strings, gauges, actual_length, perp_width, spacin
 var getDisplayOptions = function() {
 
     var showStrings = $("#showStrings").attr("checked");
+    var showFretboardEdges = $("#showFretboardEdges").attr("checked");
     var showMetas = $("#showMetas").attr("checked");
     var showBoundingBox = $("#showBoundingBox").attr("checked");
+    var showFrets = $("#showFrets").attr("checked");
     var extendFrets = $("#extendFrets").attr("checked");
 
     return {
         showStrings: showStrings,
+        showFretboardEdges: showFretboardEdges,
         showMetas: showMetas,
         showBoundingBox: showBoundingBox,
+        showFrets: showFrets,
         extendFrets: extendFrets
     };
     
@@ -442,9 +446,11 @@ as well as fretboards for instruments that play just or meantone scales.
         </dd>
         <dd>display</dd>
         <dd>
-            <label><input type="checkbox" name="showStrings" id="showStrings" checked="checked">show strings</label><br />
-            <label><input type="checkbox" name="showMetas" id="showMetas" checked="checked">show metas</label><br />
+            <label><input type="checkbox" name="showFretboardEdges" id="showFretboardEdges" checked="checked" />show fretboard edges</label><br />
+            <label><input type="checkbox" name="showStrings" id="showStrings" checked="checked" />show strings</label><br />
+            <label><input type="checkbox" name="showMetas" id="showMetas" checked="checked" />show metas</label><br />
             <label><input type="checkbox" name="showBoundingBox" id="showBoundingBox" />bounding box</label><br />
+            <label><input type="checkbox" name="showFrets" id="showFrets" checked="checked" />show frets</label><br />
             <label><input type="checkbox" name="extendFrets" id="extendFrets" />extend frets to edge</label>
         </dd>
         <dd class="help">

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -449,7 +449,7 @@ as well as fretboards for instruments that play just or meantone scales.
         </dd>
         <dd class="help">
             Selecting or deselecting any of these options will only affect the display and output files.
-            No fret
+            No fret calculations will be affected.
         </dd>
         <dt>scale length</dt>
         <dd>

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -299,10 +299,8 @@ var processChanges = false;
 var onChange = function() {
     if (processChanges) {
         var guitar = getGuitar();
-        var displayOptions = getDisplayOptions();
-        console.log('show bounding box = ' + displayOptions.showBoundingBox);
         guitar = ff.fretGuitar(guitar);
-        ff.drawGuitar(paper, guitar, displayOptions);
+        ff.drawGuitar(paper, guitar, getDisplayOptions());
         $('#tables').html(ff.getTable(guitar));
         $('#bookmark').attr('href', getLink());
     }
@@ -355,7 +353,7 @@ $(document).ready(function() {
         $('#download_dxf').click(function(){
             var guitar = getGuitar();
             guitar = ff.fretGuitar(guitar);
-            var blob = new Blob([ff.getDXF(guitar)], {type: "image/vnd.dxf"});
+            var blob = new Blob([ff.getDXF(guitar, getDisplayOptions())], {type: "image/vnd.dxf"});
             saveAs(blob, "fretboard.dxf");
         });
     
@@ -369,7 +367,7 @@ $(document).ready(function() {
             var guitar = getGuitar();
             var pagesize = $("input:checked[name='pdfm_pagesize']").val();
             guitar = ff.fretGuitar(guitar);
-            var blob = new Blob([ff.getPDFMultipage(guitar, pagesize)], {type: "application/pdf"});
+            var blob = new Blob([ff.getPDFMultipage(guitar, getDisplayOptions(), pagesize)], {type: "application/pdf"});
             saveAs(blob, "fretboard.pdf");
         });
         
@@ -377,7 +375,7 @@ $(document).ready(function() {
         $('#download_pdf').click(function(){
             var guitar = getGuitar();
             guitar = ff.fretGuitar(guitar);
-            var blob = new Blob([ff.getPDF(guitar)], {type: "application/pdf"});
+            var blob = new Blob([ff.getPDF(guitar, getDisplayOptions())], {type: "application/pdf"});
             saveAs(blob, "fretboard.pdf");
         });
         
@@ -385,7 +383,7 @@ $(document).ready(function() {
         $('#download_svg').click(function(){
             var guitar = getGuitar();
             guitar = ff.fretGuitar(guitar);
-            var blob = new Blob([ff.getSVG(guitar)], {type: "image/svg+xml"});
+            var blob = new Blob([ff.getSVG(guitar, getDisplayOptions())], {type: "image/svg+xml"});
             saveAs(blob, "fretboard.svg");
         });
         

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -92,7 +92,6 @@ var getDisplayOptions = function() {
     var showFretboardEdges = $("#showFretboardEdges").attr("checked");
     var showMetas = $("#showMetas").attr("checked");
     var showBoundingBox = $("#showBoundingBox").attr("checked");
-    var showFrets = $("#showFrets").attr("checked");
     var extendFrets = $("#extendFrets").attr("checked");
 
     return {
@@ -100,7 +99,6 @@ var getDisplayOptions = function() {
         showFretboardEdges: showFretboardEdges,
         showMetas: showMetas,
         showBoundingBox: showBoundingBox,
-        showFrets: showFrets,
         extendFrets: extendFrets
     };
     
@@ -448,7 +446,6 @@ as well as fretboards for instruments that play just or meantone scales.
         <dd>
             <label><input type="checkbox" name="showFretboardEdges" id="showFretboardEdges" checked="checked" />show fretboard edges</label><br />
             <label><input type="checkbox" name="showStrings" id="showStrings" checked="checked" />show strings</label><br />
-            <label><input type="checkbox" name="showFrets" id="showFrets" checked="checked" />show frets</label><br />
             <label><input type="checkbox" name="extendFrets" id="extendFrets" />extend frets to edge</label><br />
             <label><input type="checkbox" name="showBoundingBox" id="showBoundingBox" />bounding box</label><br />
             <label><input type="checkbox" name="showMetas" id="showMetas" checked="checked" />show metas</label>

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -85,9 +85,9 @@ var computeOffsets = function(strings, gauges, actual_length, perp_width, spacin
     return offsets;
 };
 
+// get the user-selected display options for on-screen display and all output options (i.e. SVG, PDF).
 var getDisplayOptions = function() {
 
-    
     var showStrings = $("#showStrings").attr("checked");
     var showMetas = $("#showMetas").attr("checked");
     var showBoundingBox = $("#showBoundingBox").attr("checked");

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -448,10 +448,10 @@ as well as fretboards for instruments that play just or meantone scales.
         <dd>
             <label><input type="checkbox" name="showFretboardEdges" id="showFretboardEdges" checked="checked" />show fretboard edges</label><br />
             <label><input type="checkbox" name="showStrings" id="showStrings" checked="checked" />show strings</label><br />
-            <label><input type="checkbox" name="showMetas" id="showMetas" checked="checked" />show metas</label><br />
-            <label><input type="checkbox" name="showBoundingBox" id="showBoundingBox" />bounding box</label><br />
             <label><input type="checkbox" name="showFrets" id="showFrets" checked="checked" />show frets</label><br />
-            <label><input type="checkbox" name="extendFrets" id="extendFrets" />extend frets to edge</label>
+            <label><input type="checkbox" name="extendFrets" id="extendFrets" />extend frets to edge</label><br />
+            <label><input type="checkbox" name="showBoundingBox" id="showBoundingBox" />bounding box</label><br />
+            <label><input type="checkbox" name="showMetas" id="showMetas" checked="checked" />show metas</label>
         </dd>
         <dd class="help">
             Selecting or deselecting any of these options will only affect the display and output files.

--- a/src/fretfind.html
+++ b/src/fretfind.html
@@ -85,6 +85,22 @@ var computeOffsets = function(strings, gauges, actual_length, perp_width, spacin
     return offsets;
 };
 
+var getDisplayOptions = function() {
+
+    
+    var showStrings = $("#showStrings").attr("checked");
+    var showMetas = $("#showMetas").attr("checked");
+    var showBoundingBox = $("#showBoundingBox").attr("checked");
+    var extendFrets = $("#extendFrets").attr("checked");
+
+    return {
+        showStrings: showStrings,
+        showMetas: showMetas,
+        showBoundingBox: showBoundingBox,
+        extendFrets: extendFrets
+    };
+    
+}
 
 // output a guitar (scale, tuning and strings (with fretboard edges))
 // based upon form values
@@ -283,8 +299,10 @@ var processChanges = false;
 var onChange = function() {
     if (processChanges) {
         var guitar = getGuitar();
+        var displayOptions = getDisplayOptions();
+        console.log('show bounding box = ' + displayOptions.showBoundingBox);
         guitar = ff.fretGuitar(guitar);
-        ff.drawGuitar(paper, guitar);
+        ff.drawGuitar(paper, guitar, displayOptions);
         $('#tables').html(ff.getTable(guitar));
         $('#bookmark').attr('href', getLink());
     }
@@ -422,6 +440,17 @@ as well as fretboards for instruments that play just or meantone scales.
             <label><input type="radio" name="units" value="in" checked="checked"/>inches</label>
             <label><input type="radio" name="units" value="cm" />centimeters</label>
             <label><input type="radio" name="units" value="mm" />millimeters</label>
+        </dd>
+        <dd>display</dd>
+        <dd>
+            <label><input type="checkbox" name="showStrings" id="showStrings" checked="checked">show strings</label><br />
+            <label><input type="checkbox" name="showMetas" id="showMetas" checked="checked">show metas</label><br />
+            <label><input type="checkbox" name="showBoundingBox" id="showBoundingBox" />bounding box</label><br />
+            <label><input type="checkbox" name="extendFrets" id="extendFrets" />extend frets to edge</label>
+        </dd>
+        <dd class="help">
+            Selecting or deselecting any of these options will only affect the display and output files.
+            No fret
         </dd>
         <dt>scale length</dt>
         <dd>

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -383,20 +383,44 @@ var ff = (function(){
         var extendedFretEnds = [];
         if(parallelFrets) {
             
-            for(var j=0; j<strings[0].length; j++) {
+            var lastFretIndex = strings.length - 1;
+            var endX = Math.abs(guitar.edge2.end2.x - guitar.edge1.end2.x);
+            for(var j=0; j<guitar.fret_count; j++) {
+
                 var leftStart = new Point(0, strings[0][j].fret.end1.y);
                 var leftEnd = new Point(strings[0][j].fret.end1.x, strings[0][j].fret.end1.y);
                 extendedFretEnds.push(new Segment(leftStart, leftEnd));
-            }
-
-            var endX = Math.abs(guitar.edge2.end2.x - guitar.edge1.end2.x);
-            var lastFretIndex = strings.length - 1;
-            for(var j=0; j<strings[lastFretIndex].length; j++) {
+                
                 var rightStart = new Point(strings[lastFretIndex][j].fret.end2.x, strings[lastFretIndex][j].fret.end1.y);
                 var rightEnd = new Point(endX, strings[lastFretIndex][j].fret.end1.y);
                 extendedFretEnds.push(new Segment(rightStart, rightEnd));
+
             }
 
+        }
+        else {
+            
+            var endX = Math.abs(guitar.edge2.end2.x - guitar.edge1.end2.x);
+            for(var j=0; j<=guitar.fret_count; j++) {
+
+                var firstPoint = strings[strings.length-1][j].fret.end2;
+                var lastPoint = strings[0][j].fret.end1;
+
+                var slope = (lastPoint.y - firstPoint.y) / (lastPoint.x - firstPoint.x);
+                if(Math.abs(slope) < threshold) {
+                    slope = 0;
+                }
+
+                var b = firstPoint.y - slope * firstPoint.x;
+
+                var leftPoint = new Point(0, b);
+                extendedFretEnds.push(new Segment(leftPoint, firstPoint));
+                
+                var rightPoint = new Point(endX, slope * endX + b);
+                extendedFretEnds.push(new Segment(lastPoint, rightPoint));
+
+            }
+            
         }
 
         guitar.frets = strings;

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -644,7 +644,7 @@ var ff = (function(){
         }
 
         if(displayOptions.showBoundingBox) {
-            var bbox = getExtents(guitar); // new BoundingBox(guitar.edge1, guitar.edge2);
+            var bbox = getExtents(guitar);
             output.push('<rect x="' + bbox.minx + '" y="' + bbox.miny + '"' +
                 ' width="' + bbox.width + '" height="' + bbox.height + '"' +
                 ' class="bbox" />\n');
@@ -895,7 +895,7 @@ var ff = (function(){
     
                 if(displayOptions.showBoundingBox) {
                     // draw a bounding box
-                    var bbox = getExtents(guitar); //new BoundingBox(guitar.edge1, guitar.edge2);
+                    var bbox = getExtents(guitar);
                     pdf.rect(bbox.minx - xOffset, bbox.miny - yOffset, bbox.width, bbox.height);
                 }
 

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -591,7 +591,7 @@ var ff = (function(){
         };
     };
     
-    var getSVG = function(guitar) {
+    var getSVG = function(guitar, displayOptions) {
         var x = getExtents(guitar);
         var fret_class = guitar.doPartials ? 'pfret': 'ifret';
         output = ['<svg xmlns="http://www.w3.org/2000/svg" viewBox="'+x.minx+' '+x.miny+' '+x.maxx+' '+x.maxy+
@@ -605,18 +605,25 @@ var ff = (function(){
                     '\t.bbox{stroke:rgb(0,0,0);stroke-width:0.2%;fill:rgba(0,0,0,0)}\n'+
                     ']'+']></style></defs>\n');
         //Output SVG line elements for each string.
-        for (var i=0; i<guitar.strings.length; i++) {
-            var string = guitar.strings[i];
-            output.push('<line x1="'+string.end1.x+'" x2="'+string.end2.x+
-                '" y1="'+string.end1.y+'" y2="'+string.end2.y+'"'+
-                ' class="string" />\n');
+
+        if(displayOptions.showStrings) {
+            for (var i=0; i<guitar.strings.length; i++) {
+                var string = guitar.strings[i];
+                output.push('<line x1="'+string.end1.x+'" x2="'+string.end2.x+
+                    '" y1="'+string.end1.y+'" y2="'+string.end2.y+'"'+
+                    ' class="string" />\n');
+            }
         }
-        for (var i=0; i<guitar.meta.length; i++) {
-            var meta = guitar.meta[i];
-            output.push('<line x1="'+meta.end1.x+'" x2="'+meta.end2.x+
-                '" y1="'+meta.end1.y+'" y2="'+meta.end2.y+'"'+
-                ' class="meta" />\n');
+
+        if(displayOptions.showMetas) {
+            for (var i=0; i<guitar.meta.length; i++) {
+                var meta = guitar.meta[i];
+                output.push('<line x1="'+meta.end1.x+'" x2="'+meta.end2.x+
+                    '" y1="'+meta.end1.y+'" y2="'+meta.end2.y+'"'+
+                    ' class="meta" />\n');
+            }
         }
+
         //Output SVG line elements for each fretboard edge
         output.push('<line x1="'+guitar.edge1.end1.x+'" x2="'+guitar.edge1.end2.x+
             '" y1="'+guitar.edge1.end1.y+'" y2="'+guitar.edge1.end2.y,'"'+
@@ -625,10 +632,12 @@ var ff = (function(){
             '" y1="'+guitar.edge2.end1.y+'" y2="'+guitar.edge2.end2.y,'"'+
             ' class="edge" />\n');
 
-        var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-        output.push('<rect x="' + bbox.x + '" y="' + bbox.y + '"' +
-            ' width="' + bbox.width + '" height="' + bbox.height + '"' +
-            ' class="bbox" />\n');
+        if(displayOptions.showBoundingBox) {
+            var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
+            output.push('<rect x="' + bbox.x + '" y="' + bbox.y + '"' +
+                ' width="' + bbox.width + '" height="' + bbox.height + '"' +
+                ' class="bbox" />\n');
+        }
 
         //output as SVG path for each fretlet. 
         //using paths because they allow for the linecap style 
@@ -699,7 +708,7 @@ var ff = (function(){
         return getDelimited(guitar, '\t', function(x){return x;});
     };
     
-    var getPDF = function(guitar) {
+    var getPDF = function(guitar, displayOptions) {
         var x = getExtents(guitar);
         
         var unitMult = 1;
@@ -716,18 +725,22 @@ var ff = (function(){
 
         doc.setLineWidth(lineWidth);
 
-        //Output center line
-        doc.line(guitar.center + margin, 0, guitar.center + margin, x.maxy + (2 * margin));
+        if(displayOptions.showMetas) {
+            //Output center line
+            doc.line(guitar.center + margin, 0, guitar.center + margin, x.maxy + (2 * margin));
+        }
 
-        //Output line for each string.
-        for (var i=0; i<guitar.strings.length; i++) {
-            var string = guitar.strings[i];
-            doc.line(
-                string.end1.x + margin, 
-                string.end1.y + margin, 
-                string.end2.x + margin, 
-                string.end2.y + margin
-                );
+        if(displayOptions.showStrings) {
+            //Output line for each string.
+            for (var i=0; i<guitar.strings.length; i++) {
+                var string = guitar.strings[i];
+                doc.line(
+                    string.end1.x + margin, 
+                    string.end1.y + margin, 
+                    string.end2.x + margin, 
+                    string.end2.y + margin
+                    );
+            }
         }
         
         //Output line for each fretboard edge
@@ -745,9 +758,11 @@ var ff = (function(){
             );
 
 
-        // draw a bounding box
-        var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-        doc.rect(bbox.x + margin, bbox.y + margin, bbox.width, bbox.height);
+        if(displayOptions.showBoundingBox) {
+            // draw a bounding box
+            var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
+            doc.rect(bbox.x + margin, bbox.y + margin, bbox.width, bbox.height);
+        }
 
         //Output a line for each fretlet. 
         for (var i=0; i<guitar.frets.length; i++) {
@@ -764,7 +779,7 @@ var ff = (function(){
         return doc.output();
     };
     
-    var getPDFMultipage = function(guitar, pagesize) {
+    var getPDFMultipage = function(guitar, displayOptions, pagesize) {
         var x = getExtents(guitar);
         
         // pagesize is either a4 or letter
@@ -808,17 +823,21 @@ var ff = (function(){
                 pdf.rect(pageOverlap, pageOverlap, printableWidth, printableHeight);        
                 pdf.setDrawColor(0);
         
-                //Output center line
-                pdf.line(guitar.center - xOffset, 0, guitar.center - xOffset, pageHeight);
+                if(displayOptions.showMetas) {
+                    //Output center line
+                    pdf.line(guitar.center - xOffset, 0, guitar.center - xOffset, pageHeight);
+                }
 
-                //output a line for each string
-                for (var k=0; k<guitar.strings.length; k++) {
-                    pdf.line(
-                        guitar.strings[k].end1.x - xOffset,
-                        guitar.strings[k].end1.y - yOffset,
-                        guitar.strings[k].end2.x - xOffset,
-                        guitar.strings[k].end2.y - yOffset
-                        );
+                if(displayOptions.showStrings) {
+                    //output a line for each string
+                    for (var k=0; k<guitar.strings.length; k++) {
+                        pdf.line(
+                            guitar.strings[k].end1.x - xOffset,
+                            guitar.strings[k].end1.y - yOffset,
+                            guitar.strings[k].end2.x - xOffset,
+                            guitar.strings[k].end2.y - yOffset
+                            );
+                    }
                 }
     
                 //output a line for each fretboard edge
@@ -835,9 +854,11 @@ var ff = (function(){
                     guitar.edge2.end2.y - yOffset
                     );
     
-                // draw a bounding box
-                var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-                pdf.rect(bbox.x - xOffset, bbox.y - yOffset, bbox.width, bbox.height);
+                if(displayOptions.showBoundingBox) {
+                    // draw a bounding box
+                    var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
+                    pdf.rect(bbox.x - xOffset, bbox.y - yOffset, bbox.width, bbox.height);
+                }
 
                 //output a line for each fret on each string
                 for (var k=0; k<guitar.frets.length; k++) {
@@ -857,7 +878,7 @@ var ff = (function(){
     
     // TODO: 
     // - more compatible DXF borrowing from inkscape?
-    var getDXF = function(guitar) {
+    var getDXF = function(guitar, displayOptions) {
         //References: Minimum Requirements for Creating a DXF File of a 3D Model By Paul Bourke
         var seg2dxf = function(seg, dot) {
             if (typeof dot === 'undefined') {
@@ -878,30 +899,34 @@ var ff = (function(){
         output.push('999\nDXF created by FretFind2D\n');
         output.push('0\nSECTION\n2\nENTITIES\n');
         
-        //Output line for each string.
-        for (var i=0; i<guitar.strings.length; i++) {
-            output.push(seg2dxf(guitar.strings[i]));
+        if(displayOptions.showStrings) {
+            //Output line for each string.
+            for (var i=0; i<guitar.strings.length; i++) {
+                output.push(seg2dxf(guitar.strings[i]));
+            }
         }
         
         //Output line for each fretboard edge
         output.push(seg2dxf(guitar.edge1));
         output.push(seg2dxf(guitar.edge2));
 
-        //Output bounding box
-        var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-        var topLeft = new Point(bbox.x, bbox.y);
-        var bottomLeft = new Point(bbox.x, bbox.y+bbox.height);
-        var bottomRight = new Point(bbox.x+bbox.width, bbox.y+bbox.height);
-        var topRight = new Point(bbox.x+bbox.width, bbox.y);
-        var leftSeg = new Segment(topLeft, bottomLeft);
-        var bottomSeg = new Segment(bottomLeft, bottomRight);
-        var rightSeg = new Segment(bottomRight, topRight);
-        var topSeg = new Segment(topRight, topLeft);
+        if(displayOptions.showBoundingBox) {
+            //Output bounding box
+            var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
+            var topLeft = new Point(bbox.x, bbox.y);
+            var bottomLeft = new Point(bbox.x, bbox.y+bbox.height);
+            var bottomRight = new Point(bbox.x+bbox.width, bbox.y+bbox.height);
+            var topRight = new Point(bbox.x+bbox.width, bbox.y);
+            var leftSeg = new Segment(topLeft, bottomLeft);
+            var bottomSeg = new Segment(bottomLeft, bottomRight);
+            var rightSeg = new Segment(bottomRight, topRight);
+            var topSeg = new Segment(topRight, topLeft);
 
-        output.push(seg2dxf(leftSeg));
-        output.push(seg2dxf(bottomSeg));
-        output.push(seg2dxf(rightSeg));
-        output.push(seg2dxf(topSeg));
+            output.push(seg2dxf(leftSeg));
+            output.push(seg2dxf(bottomSeg));
+            output.push(seg2dxf(rightSeg));
+            output.push(seg2dxf(topSeg));
+        }
 
         //Output a line for each fretlet. 
         for (var i=0; i<guitar.frets.length; i++) {

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -160,35 +160,6 @@ var ff = (function(){
         return 'M' + this.end1.x + ' ' + this.end1.y + 'L' + this.end2.x + ' ' + this.end2.y;
     };
     
-    function BoundingBox(seg1, seg2) {
-
-        var minX = seg1.end1.x;
-        if(seg1.end2.x < minX) minX = seg1.end2.x;
-        if(seg2.end1.x < minX) minX = seg2.end1.x;
-        if(seg2.end2.x < minX) minX = seg2.end2.x;
-
-        var minY = seg1.end1.y;
-        if(seg1.end2.y < minY) minY = seg1.end2.y;
-        if(seg2.end1.y < minY) minY = seg2.end1.y;
-        if(seg2.end2.y < minY) minY = seg2.end2.y;
-
-        var maxX = seg1.end1.x;
-        if(seg1.end2.x > maxX) maxX = seg1.end2.x;
-        if(seg2.end1.x > maxX) maxX = seg2.end1.x;
-        if(seg2.end2.x > maxX) maxX = seg2.end2.x;
-
-        var maxY = seg1.end1.y;
-        if(seg1.end2.y > maxY) maxY = seg1.end2.y;
-        if(seg2.end1.y > maxY) maxY = seg2.end1.y;
-        if(seg2.end2.y > maxY) maxY = seg2.end2.y;
-
-        this.x = minX;
-        this.y = minY;
-        this.width = maxX - minX;
-        this.height = maxY - minY;
-
-    }
-
     function Scale() {
         // initial step 0 or 1/1 is implicit
         this.steps = [[1,1]];
@@ -541,11 +512,11 @@ var ff = (function(){
         var ends = paper.path(guitar.nut.toSVGD() + guitar.bridge.toSVGD()).attr(pfretstyle);
         all.push(ends);
         
-        var bbox = edges.getBBox();
+        var bbox = getExtents(guitar); //edges.getBBox();
         
         // draw a bounding box
         if(displayOptions.showBoundingBox) {
-            all.push(paper.rect(bbox.x, bbox.y, bbox.width, bbox.height).attr(stringstyle));
+            all.push(paper.rect(bbox.minx, bbox.miny, bbox.width, bbox.height).attr(stringstyle));
         }
 
         var fretpath = [];
@@ -641,8 +612,8 @@ var ff = (function(){
             ' class="edge" />\n');
 
         if(displayOptions.showBoundingBox) {
-            var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-            output.push('<rect x="' + bbox.x + '" y="' + bbox.y + '"' +
+            var bbox = getExtents(guitar); // new BoundingBox(guitar.edge1, guitar.edge2);
+            output.push('<rect x="' + bbox.minx + '" y="' + bbox.miny + '"' +
                 ' width="' + bbox.width + '" height="' + bbox.height + '"' +
                 ' class="bbox" />\n');
         }
@@ -776,8 +747,8 @@ var ff = (function(){
 
         if(displayOptions.showBoundingBox) {
             // draw a bounding box
-            var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-            doc.rect(bbox.x + margin, bbox.y + margin, bbox.width, bbox.height);
+            var bbox = getExtents(guitar); //new BoundingBox(guitar.edge1, guitar.edge2);
+            doc.rect(bbox.minx + margin, bbox.miny + margin, bbox.width, bbox.height);
         }
 
         //Output a line for each fretlet. 
@@ -888,8 +859,8 @@ var ff = (function(){
     
                 if(displayOptions.showBoundingBox) {
                     // draw a bounding box
-                    var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-                    pdf.rect(bbox.x - xOffset, bbox.y - yOffset, bbox.width, bbox.height);
+                    var bbox = getExtents(guitar); //new BoundingBox(guitar.edge1, guitar.edge2);
+                    pdf.rect(bbox.minx - xOffset, bbox.miny - yOffset, bbox.width, bbox.height);
                 }
 
                 //output a line for each fret on each string
@@ -955,11 +926,11 @@ var ff = (function(){
 
         if(displayOptions.showBoundingBox) {
             //Output bounding box
-            var bbox = new BoundingBox(guitar.edge1, guitar.edge2);
-            var topLeft = new Point(bbox.x, bbox.y);
-            var bottomLeft = new Point(bbox.x, bbox.y+bbox.height);
-            var bottomRight = new Point(bbox.x+bbox.width, bbox.y+bbox.height);
-            var topRight = new Point(bbox.x+bbox.width, bbox.y);
+            var bbox = getExtents(guitar); //new BoundingBox(guitar.edge1, guitar.edge2);
+            var topLeft = new Point(bbox.minx, bbox.miny);
+            var bottomLeft = new Point(bbox.minx, bbox.miny+bbox.height);
+            var bottomRight = new Point(bbox.minx+bbox.width, bbox.miny+bbox.height);
+            var topRight = new Point(bbox.minx+bbox.width, bbox.miny);
             var leftSeg = new Segment(topLeft, bottomLeft);
             var bottomSeg = new Segment(bottomLeft, bottomRight);
             var rightSeg = new Segment(bottomRight, topRight);

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -813,7 +813,12 @@ var ff = (function(){
         if (pagesize === 'a4') {
             var rawPageWidth = 210 / 25.4;
             var rawPageHeight = 297 / 25.4;
-        } else {
+        }
+        else if(pagesize === 'legal') {
+            var rawPageWidth = 8.5;
+            var rawPageHeight = 14;
+        }
+        else {
             pagesize = 'letter';
             var rawPageWidth = 8.5;
             var rawPageHeight = 11;

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -545,13 +545,6 @@ var ff = (function(){
         var ends = paper.path(guitar.nut.toSVGD() + guitar.bridge.toSVGD()).attr(pfretstyle);
         all.push(ends);
         
-        
-        // draw a bounding box
-        if(displayOptions.showBoundingBox) {
-            var bbox = getExtents(guitar);
-            all.push(paper.rect(bbox.minx, bbox.miny, bbox.width, bbox.height).attr(stringstyle));
-        }
-
         if(displayOptions.showFrets) {
             var fretpath = [];
             for (var i=0; i<guitar.frets.length; i++) {
@@ -570,6 +563,11 @@ var ff = (function(){
             }
             var extendedFrets = paper.path(extendedFretsPath.join('')).attr(fretstyle);
             all.push(extendedFrets);
+        }
+
+        if(displayOptions.showBoundingBox) {
+            var bbox = getExtents(guitar);
+            all.push(paper.rect(bbox.minx, bbox.miny, bbox.width, bbox.height).attr(stringstyle));
         }
 
         // calculate scale

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -291,8 +291,6 @@ var ff = (function(){
         }
         //var intersection = nut.intersect(bridge);
 
-        console.log("partials: " + doPartials + ", parallel: " + parallelFrets);
-
         // an array of fretlets for each string
         var strings = [];
         var tones = guitar.scale.steps.length - 1;

--- a/src/fretfind.js
+++ b/src/fretfind.js
@@ -385,7 +385,7 @@ var ff = (function(){
 
             var lastFretIndex = strings.length - 1;
             var endX = Math.abs(guitar.edge2.end2.x - guitar.edge1.end2.x);
-            for(var j=0; j<guitar.fret_count; j++) {
+            for(var j=0; j<=guitar.fret_count; j++) {
 
                 var leftStart = new Point(0, strings[0][j].fret.end1.y);
                 var leftEnd = new Point(strings[0][j].fret.end1.x, strings[0][j].fret.end1.y);
@@ -545,16 +545,14 @@ var ff = (function(){
         var ends = paper.path(guitar.nut.toSVGD() + guitar.bridge.toSVGD()).attr(pfretstyle);
         all.push(ends);
         
-        if(displayOptions.showFrets) {
-            var fretpath = [];
-            for (var i=0; i<guitar.frets.length; i++) {
-                for (var j=0; j<guitar.frets[i].length; j++) {
-                    fretpath.push(guitar.frets[i][j].fret.toSVGD());
-                }
+        var fretpath = [];
+        for (var i=0; i<guitar.frets.length; i++) {
+            for (var j=0; j<guitar.frets[i].length; j++) {
+                fretpath.push(guitar.frets[i][j].fret.toSVGD());
             }
-            var frets = paper.path(fretpath.join('')).attr(fretstyle);
-            all.push(frets);
         }
+        var frets = paper.path(fretpath.join('')).attr(fretstyle);
+        all.push(frets);
 
         if(displayOptions.extendFrets) {
             var extendedFretsPath = [];
@@ -637,13 +635,15 @@ var ff = (function(){
             }
         }
 
-        //Output SVG line elements for each fretboard edge
-        output.push('<line x1="'+guitar.edge1.end1.x+'" x2="'+guitar.edge1.end2.x+
-            '" y1="'+guitar.edge1.end1.y+'" y2="'+guitar.edge1.end2.y,'"'+
-            ' class="edge" />\n');
-        output.push('<line x1="'+guitar.edge2.end1.x+'" x2="'+guitar.edge2.end2.x+
-            '" y1="'+guitar.edge2.end1.y+'" y2="'+guitar.edge2.end2.y,'"'+
-            ' class="edge" />\n');
+        if(displayOptions.showFretboardEdges) {
+            //Output SVG line elements for each fretboard edge
+            output.push('<line x1="'+guitar.edge1.end1.x+'" x2="'+guitar.edge1.end2.x+
+                '" y1="'+guitar.edge1.end1.y+'" y2="'+guitar.edge1.end2.y,'"'+
+                ' class="edge" />\n');
+            output.push('<line x1="'+guitar.edge2.end1.x+'" x2="'+guitar.edge2.end2.x+
+                '" y1="'+guitar.edge2.end1.y+'" y2="'+guitar.edge2.end2.y,'"'+
+                ' class="edge" />\n');
+        }
 
         if(displayOptions.showBoundingBox) {
             var bbox = getExtents(guitar); // new BoundingBox(guitar.edge1, guitar.edge2);
@@ -764,19 +764,21 @@ var ff = (function(){
             }
         }
         
-        //Output line for each fretboard edge
-        doc.line(
-            guitar.edge1.end1.x + margin, 
-            guitar.edge1.end1.y + margin, 
-            guitar.edge1.end2.x + margin, 
-            guitar.edge1.end2.y + margin
-            );
-        doc.line(
-            guitar.edge2.end1.x + margin, 
-            guitar.edge2.end1.y + margin, 
-            guitar.edge2.end2.x + margin, 
-            guitar.edge2.end2.y + margin
-            );
+        if(displayOptions.showFretboardEdges) {
+            //Output line for each fretboard edge
+            doc.line(
+                guitar.edge1.end1.x + margin, 
+                guitar.edge1.end1.y + margin, 
+                guitar.edge1.end2.x + margin, 
+                guitar.edge1.end2.y + margin
+                );
+            doc.line(
+                guitar.edge2.end1.x + margin, 
+                guitar.edge2.end1.y + margin, 
+                guitar.edge2.end2.x + margin, 
+                guitar.edge2.end2.y + margin
+                );
+        }
 
 
         if(displayOptions.showBoundingBox) {
@@ -877,19 +879,21 @@ var ff = (function(){
                     }
                 }
     
-                //output a line for each fretboard edge
-                pdf.line(
-                    guitar.edge1.end1.x - xOffset,
-                    guitar.edge1.end1.y - yOffset,
-                    guitar.edge1.end2.x - xOffset,
-                    guitar.edge1.end2.y - yOffset
-                    );
-                pdf.line(
-                    guitar.edge2.end1.x - xOffset,
-                    guitar.edge2.end1.y - yOffset,
-                    guitar.edge2.end2.x - xOffset,
-                    guitar.edge2.end2.y - yOffset
-                    );
+                if(displayOptions.showFretboardEdges) {
+                    //output a line for each fretboard edge
+                    pdf.line(
+                        guitar.edge1.end1.x - xOffset,
+                        guitar.edge1.end1.y - yOffset,
+                        guitar.edge1.end2.x - xOffset,
+                        guitar.edge1.end2.y - yOffset
+                        );
+                    pdf.line(
+                        guitar.edge2.end1.x - xOffset,
+                        guitar.edge2.end1.y - yOffset,
+                        guitar.edge2.end2.x - xOffset,
+                        guitar.edge2.end2.y - yOffset
+                        );
+                }
     
                 if(displayOptions.showBoundingBox) {
                     // draw a bounding box
@@ -954,9 +958,11 @@ var ff = (function(){
             }
         }
         
-        //Output line for each fretboard edge
-        output.push(seg2dxf(guitar.edge1));
-        output.push(seg2dxf(guitar.edge2));
+        if(displayOptions.showFretboardEdges) {
+            //Output line for each fretboard edge
+            output.push(seg2dxf(guitar.edge1));
+            output.push(seg2dxf(guitar.edge2));
+        }
 
         if(displayOptions.showBoundingBox) {
             //Output bounding box


### PR DESCRIPTION
1. Added option to extend the frets beyond the edge of the fretboard display to the edge of the bounding box.  This could be useful when printing a fretboard template to use in a fret slotting miter box or other fret slotting jigs.
2. Added option to include a rectangular bounding box around the fretboard.
3. Added feature that allows a user to select which components of the fretboard to be displayed in the output diagram or files.
4. Added legal paper format (14x8.5) for multiple PDF output.
5. Added docker compose file for running an Apache/PHP server to host the application.

Sorry for multiple items in the same PR.  I can separate out if you're interested in adding any of these.